### PR TITLE
Cancoder fix

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -66,7 +66,9 @@ public class Robot extends TimedRobot {
   public void disabledInit() {}
 
   @Override
-  public void disabledPeriodic() {}
+  public void disabledPeriodic() {
+    m_robotContainer.getDriveTrain().syncSwerveAngleEncoders();
+  }
 
   /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
   @Override

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -258,6 +258,14 @@ public class DriveTrain extends SubsystemBase {
 		return state;
 	}
 	    
+	public void syncSwerveAngleEncoders() {
+		// check if we can sync the swerve angle encoders
+		// this will only trigger if the chassis is idle for 10 seconds
+		for (SwerveModule module : m_swerveModules) {
+			module.syncAngleEncoders(false);
+		}
+	}
+
 	@Override
 	public void periodic() {
 		Pose2d pose = m_odometry.update(getGyroscopeRotation(), getModulePositions());
@@ -265,12 +273,6 @@ public class DriveTrain extends SubsystemBase {
 		// Have the vision system update based on the Apriltags, if seen
 		// Comment out for now so we don't get exceptions
 		// m_vision.updateOdometry(m_odometry);
-
-		// check if we can sync the swerve angle encoders
-		// this will only trigger if the chassis is idle for 10 seconds
-		for (SwerveModule module : m_swerveModules) {
-			module.syncAngleEncoders(false);
-		}
 
 		SmartDashboard.putNumber("drivetrain/xPosition", pose.getX());
 		SmartDashboard.putNumber("drivetrain/yPosition", pose.getY());

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -138,6 +138,11 @@ public class DriveTrain extends SubsystemBase {
 				new Pose2d());
 
 		m_vision = new Vision();
+
+		// as late as possible, re-sync the swerve angle encoders
+		for (SwerveModule module : m_swerveModules) {
+			module.syncAngleEncoders(true);
+		}
 	}
 
 	/**
@@ -260,6 +265,12 @@ public class DriveTrain extends SubsystemBase {
 		// Have the vision system update based on the Apriltags, if seen
 		// Comment out for now so we don't get exceptions
 		// m_vision.updateOdometry(m_odometry);
+
+		// check if we can sync the swerve angle encoders
+		// this will only trigger if the chassis is idle for 10 seconds
+		for (SwerveModule module : m_swerveModules) {
+			module.syncAngleEncoders(false);
+		}
 
 		SmartDashboard.putNumber("drivetrain/xPosition", pose.getX());
 		SmartDashboard.putNumber("drivetrain/yPosition", pose.getY());

--- a/src/main/java/frc/robot/swerve/CanCoderWrapper.java
+++ b/src/main/java/frc/robot/swerve/CanCoderWrapper.java
@@ -25,6 +25,7 @@ public class CanCoderWrapper {
 
     public CanCoderWrapper(int canId, double offset) {
         m_encoder = new CANCoder(canId);
+        System.out.println("CanCoder reading before config " + m_encoder.getAbsolutePosition());
 
         CANCoderConfiguration config = new CANCoderConfiguration();
         config.absoluteSensorRange = AbsoluteSensorRange.Unsigned_0_to_360;

--- a/src/main/java/frc/robot/swerve/CanCoderWrapper.java
+++ b/src/main/java/frc/robot/swerve/CanCoderWrapper.java
@@ -25,7 +25,6 @@ public class CanCoderWrapper {
 
     public CanCoderWrapper(int canId, double offset) {
         m_encoder = new CANCoder(canId);
-        System.out.println("CanCoder reading before config " + m_encoder.getAbsolutePosition());
 
         CANCoderConfiguration config = new CANCoderConfiguration();
         config.absoluteSensorRange = AbsoluteSensorRange.Unsigned_0_to_360;
@@ -37,8 +36,6 @@ public class CanCoderWrapper {
 
         checkCtreError(m_encoder.setStatusFramePeriod(CANCoderStatusFrame.SensorData, PERIOD_MILLISECONDS, 250),
                 "Failed to configure CANCoder update rate");
-
-        System.out.println("Initial CanCoder reading " + m_encoder.getAbsolutePosition());
     };
 
     // get the absolute angle, in radians

--- a/src/main/java/frc/robot/swerve/CanCoderWrapper.java
+++ b/src/main/java/frc/robot/swerve/CanCoderWrapper.java
@@ -10,7 +10,7 @@ import edu.wpi.first.wpilibj.DriverStation;
 
 // A wrapper around the CANCoder absolute angle sensor
 
-public class CanCoder {
+public class CanCoderWrapper {
     private static final int PERIOD_MILLISECONDS = 100;
     private static final boolean ROTATION_CLOCKWISE = false;
 
@@ -22,7 +22,7 @@ public class CanCoder {
         }
     }
 
-    public CanCoder(int canId, double offset) {
+    public CanCoderWrapper(int canId, double offset) {
         m_encoder = new CANCoder(canId);
 
         CANCoderConfiguration config = new CANCoderConfiguration();

--- a/src/main/java/frc/robot/swerve/CanCoderWrapper.java
+++ b/src/main/java/frc/robot/swerve/CanCoderWrapper.java
@@ -19,6 +19,7 @@ public class CanCoderWrapper {
     public static void checkCtreError(ErrorCode errorCode, String message) {
         if (errorCode != ErrorCode.OK) {
             DriverStation.reportError(String.format("%s: %s", message, errorCode.toString()), false);
+            System.out.println("** ERROR in config of CANCoder: " + errorCode.toString());
         }
     }
 
@@ -35,6 +36,8 @@ public class CanCoderWrapper {
 
         checkCtreError(m_encoder.setStatusFramePeriod(CANCoderStatusFrame.SensorData, PERIOD_MILLISECONDS, 250),
                 "Failed to configure CANCoder update rate");
+
+        System.out.println("Initial CanCoder reading " + m_encoder.getAbsolutePosition());
     };
 
     // get the absolute angle, in radians

--- a/src/main/java/frc/robot/swerve/NeoSteerController.java
+++ b/src/main/java/frc/robot/swerve/NeoSteerController.java
@@ -33,6 +33,7 @@ public class NeoSteerController {
     static void checkNeoError(REVLibError error, String message) {
         if (error != REVLibError.kOk) {
             DriverStation.reportError(String.format("%s: %s", message, error.toString()), false);
+            System.out.println(String.format("%s: %s", message, error.toString()));
         }
     }
 
@@ -71,6 +72,7 @@ public class NeoSteerController {
                 "Failed to set NEO encoder conversion factor");
 
         // set the built in encoder to match the CANcoder
+        System.out.println("*** Setting steer encoder to " + m_absoluteEncoder.getAbsoluteAngle());
         checkNeoError(m_motorEncoder.setPosition(m_absoluteEncoder.getAbsoluteAngle()),
                 "Failed to set NEO encoder position");
 
@@ -89,7 +91,6 @@ public class NeoSteerController {
 
     // set the angle we want for the wheel (radians)
     public void setReferenceAngle(double referenceAngleRadians) {
-        double currentAngleRadians = m_motorEncoder.getPosition();
 
         // Reset the NEO's encoder periodically when the module is not rotating.
         // Sometimes (~5% of the time) when we initialize, the absolute encoder isn't
@@ -100,12 +101,14 @@ public class NeoSteerController {
             if (++m_resetIteration >= ENCODER_RESET_ITERATIONS) {
                 m_resetIteration = 0;
                 double absoluteAngle = m_absoluteEncoder.getAbsoluteAngle();
+                System.out.println("*** Resetting steer encoder to " + absoluteAngle);
                 m_motorEncoder.setPosition(absoluteAngle);
-                currentAngleRadians = absoluteAngle;
             }
         } else {
             m_resetIteration = 0;
         }
+
+        double currentAngleRadians = m_motorEncoder.getPosition();
 
         // force into 0 -> 2*PI
         double currentAngleRadiansMod = currentAngleRadians % (2.0 * Math.PI);

--- a/src/main/java/frc/robot/swerve/NeoSteerController.java
+++ b/src/main/java/frc/robot/swerve/NeoSteerController.java
@@ -25,7 +25,7 @@ public class NeoSteerController {
     private final CANSparkMax m_motor;
     private final SparkMaxPIDController m_controller;
     private final RelativeEncoder m_motorEncoder;
-    private final CanCoder m_absoluteEncoder;
+    private final CanCoderWrapper m_absoluteEncoder;
 
     private double m_referenceAngleRadians = 0;
     private double m_resetIteration = 0;
@@ -38,7 +38,7 @@ public class NeoSteerController {
 
     public NeoSteerController(int canId, int canCoderCanId, double angleOffset) {
         // absolute angle encoder CANcoder
-        m_absoluteEncoder = new CanCoder(canCoderCanId, angleOffset);
+        m_absoluteEncoder = new CanCoderWrapper(canCoderCanId, angleOffset);
 
         // the turn motor
         m_motor = new CANSparkMax(canId, CANSparkMaxLowLevel.MotorType.kBrushless);

--- a/src/main/java/frc/robot/swerve/SwerveModule.java
+++ b/src/main/java/frc/robot/swerve/SwerveModule.java
@@ -71,4 +71,8 @@ public class SwerveModule {
     public void updateSmartDashboard(String prefix) {
         m_steerController.updateSmartDashboard(prefix + "_steer");
     }
+
+    public void syncAngleEncoders(boolean dontCheckTimer) {
+        m_steerController.syncAngleEncoders(dontCheckTimer);
+    }
 }


### PR DESCRIPTION
Fix the initialization of the CANcoder and motor encoders in the swerve steer modules.
It appears that initializing them too *early* can cause them to be out of sync, and then the module does not orient correctly. Re-try the synchronization at the end of the Drivetrain constructor, and then redo every 10 seconds when disabled.