### PR TITLE
Simplify swerve offset calibration

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,13 +4,11 @@
 
 package frc.robot;
 
-import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import edu.wpi.first.wpilibj2.command.ScheduleCommand;
 
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to
@@ -30,16 +28,21 @@ public class Robot extends TimedRobot {
   @Override
   public void robotInit() {
 
-    if(this.isSimulation()){
-      //At-Home Network Debug Only - host the NT server on photonvision and connect to it.
-      NetworkTableInstance.getDefault().stopServer();
-      // NetworkTableInstance.getDefault().setServer("photonvision.local");
-      NetworkTableInstance.getDefault().setServer("127.0.0.1");
-      NetworkTableInstance.getDefault().startClient4("MainRobotProgram");
-    }
-    // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
-    // autonomous chooser on the dashboard.
+    // If you are trying to work with a running PV and simulation, enable this code.
+    // Otherwise it is not needed, even when running a simulation
+    // if (isSimulation()) {
+    //   // At-Home Network Debug Only - host the NT server on photonvision and connect to it.
+    //   var ntinst = edu.wpi.first.networktables.NetworkTableInstance.getDefault();
+    //   ntinst.stopServer();
+    //   // ntinst.setServer("photonvision.local");
+    //   ntinst.setServer("127.0.0.1");
+    //   ntinst.startClient4("MainRobotProgram");
+    // }
+    
+    // Instantiate our RobotContainer.  This will perform all our button bindings.
     m_robotContainer = new RobotContainer();
+
+    // Initialize the list of available Autonomous routines
     m_chosenTrajectory.setDefaultOption("drive_1m", m_robotContainer.getDriveTrain().getTrajectoryFollowingCommand("drive_1m"));
     m_chosenTrajectory.addOption("drive_and_slide", m_robotContainer.getDriveTrain().getTrajectoryFollowingCommand("drive_and_slide"));
     m_chosenTrajectory.addOption("drive_and_turn", m_robotContainer.getDriveTrain().getTrajectoryFollowingCommand("drive_and_turn"));

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -24,33 +24,33 @@ public class Robot extends TimedRobot {
     private SendableChooser<Command> m_chosenTrajectory = new SendableChooser<>();
     private RobotContainer m_robotContainer;
 
-  /**
-   * This function is run when the robot is first started up and should be used for any
-   * initialization code.
-   */
-  @Override
-  public void robotInit() {
+    /**
+     * This function is run when the robot is first started up and should be used for any
+     * initialization code.
+     */
+    @Override
+    public void robotInit() {
 
-    // If you are trying to work with a running PV and simulation, enable this code.
-    // Otherwise it is not needed, even when running a simulation
-    // if (isSimulation()) {
-    //   // At-Home Network Debug Only - host the NT server on photonvision and connect to it.
-    //   var ntinst = edu.wpi.first.networktables.NetworkTableInstance.getDefault();
-    //   ntinst.stopServer();
-    //   // ntinst.setServer("photonvision.local");
-    //   ntinst.setServer("127.0.0.1");
-    //   ntinst.startClient4("MainRobotProgram");
-    // }
-    
-    // Instantiate our RobotContainer.  This will perform all our button bindings.
-    m_robotContainer = new RobotContainer();
+        // If you are trying to work with a running PV and simulation, enable this code.
+        // Otherwise it is not needed, even when running a simulation
+        // if (isSimulation()) {
+        //   // At-Home Network Debug Only - host the NT server on photonvision and connect to it.
+        //   var ntinst = edu.wpi.first.networktables.NetworkTableInstance.getDefault();
+        //   ntinst.stopServer();
+        //   // ntinst.setServer("photonvision.local");
+        //   ntinst.setServer("127.0.0.1");
+        //   ntinst.startClient4("MainRobotProgram");
+        // }
+        
+        // Instantiate our RobotContainer.  This will perform all our button bindings.
+        m_robotContainer = new RobotContainer();
 
-    // Initialize the list of available Autonomous routines
-    m_chosenTrajectory.setDefaultOption("drive_1m", m_robotContainer.getDriveTrain().getTrajectoryFollowingCommand("drive_1m"));
-    m_chosenTrajectory.addOption("drive_and_slide", m_robotContainer.getDriveTrain().getTrajectoryFollowingCommand("drive_and_slide"));
-    m_chosenTrajectory.addOption("drive_and_turn", m_robotContainer.getDriveTrain().getTrajectoryFollowingCommand("drive_and_turn"));
-    SmartDashboard.putData("Chosen Trajectory", m_chosenTrajectory);
-  }
+        // Initialize the list of available Autonomous routines
+        m_chosenTrajectory.setDefaultOption("drive_1m", m_robotContainer.getDriveTrain().getTrajectoryFollowingCommand("drive_1m"));
+        m_chosenTrajectory.addOption("drive_and_slide", m_robotContainer.getDriveTrain().getTrajectoryFollowingCommand("drive_and_slide"));
+        m_chosenTrajectory.addOption("drive_and_turn", m_robotContainer.getDriveTrain().getTrajectoryFollowingCommand("drive_and_turn"));
+        SmartDashboard.putData("Chosen Trajectory", m_chosenTrajectory);
+    }
 
     /**
      * This function is called every robot packet, no matter the mode. Use this for

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,13 +8,11 @@ import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 
 import frc.robot.commands.Drive;
 import frc.robot.commands.ChargeStationBalance;
-import frc.robot.commands.ChargeStationDrive;
 
 import frc.robot.subsystems.DriveTrain;
 import frc.robot.subsystems.Vision;

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -115,22 +115,22 @@ public class DriveTrain extends SubsystemBase {
 
 	public DriveTrain(Vision vision) {
 
-		m_swerveModules[0] = new SwerveModule(
+		m_swerveModules[0] = new SwerveModule("frontLeft",
 				new frc.robot.swerve.NeoDriveController(FRONT_LEFT_MODULE_DRIVE_MOTOR),
 				new frc.robot.swerve.NeoSteerController(FRONT_LEFT_MODULE_STEER_MOTOR, FRONT_LEFT_MODULE_STEER_ENCODER,
 						FRONT_LEFT_MODULE_STEER_OFFSET));
 
-		m_swerveModules[1] = new frc.robot.swerve.SwerveModule(
+		m_swerveModules[1] = new frc.robot.swerve.SwerveModule("frontRight",
 				new frc.robot.swerve.NeoDriveController(FRONT_RIGHT_MODULE_DRIVE_MOTOR),
 				new frc.robot.swerve.NeoSteerController(FRONT_RIGHT_MODULE_STEER_MOTOR,
 						FRONT_RIGHT_MODULE_STEER_ENCODER, FRONT_RIGHT_MODULE_STEER_OFFSET));
 
-		m_swerveModules[2] = new frc.robot.swerve.SwerveModule(
+		m_swerveModules[2] = new frc.robot.swerve.SwerveModule("backLeft",
 				new frc.robot.swerve.NeoDriveController(BACK_LEFT_MODULE_DRIVE_MOTOR),
 				new frc.robot.swerve.NeoSteerController(BACK_LEFT_MODULE_STEER_MOTOR, BACK_LEFT_MODULE_STEER_ENCODER,
 						BACK_LEFT_MODULE_STEER_OFFSET));
 
-		m_swerveModules[3] = new frc.robot.swerve.SwerveModule(
+		m_swerveModules[3] = new frc.robot.swerve.SwerveModule("backRight",
 				new frc.robot.swerve.NeoDriveController(BACK_RIGHT_MODULE_DRIVE_MOTOR),
 				new frc.robot.swerve.NeoSteerController(BACK_RIGHT_MODULE_STEER_MOTOR, BACK_RIGHT_MODULE_STEER_ENCODER,
 						BACK_RIGHT_MODULE_STEER_OFFSET));
@@ -284,10 +284,9 @@ public class DriveTrain extends SubsystemBase {
 
 		SmartDashboard.putBoolean("drivetrain/fieldCentric", m_fieldCentric);
 
-		m_swerveModules[0].updateSmartDashboard("drivetrain/frontLeft");
-		m_swerveModules[1].updateSmartDashboard("drivetrain/frontRight");
-		m_swerveModules[2].updateSmartDashboard("drivetrain/backLeft");
-		m_swerveModules[3].updateSmartDashboard("drivetrain/backRight");
+		for (SwerveModule mod : m_swerveModules) {
+			mod.updateSmartDashboard();
+		}
 	}
 
 	// get the trajectory following autonomous command in PathPlanner using the name

--- a/src/main/java/frc/robot/swerve/CanCoderWrapper.java
+++ b/src/main/java/frc/robot/swerve/CanCoderWrapper.java
@@ -16,6 +16,9 @@ public class CanCoderWrapper {
 
     private final CANCoder m_encoder;
 
+    // remember the offsetAngle to simplify recalibration of the offset
+    private final double m_offsetAngleRadians;
+
     public static void checkCtreError(ErrorCode errorCode, String message) {
         if (errorCode != ErrorCode.OK) {
             DriverStation.reportError(String.format("%s: %s", message, errorCode.toString()), false);
@@ -23,12 +26,13 @@ public class CanCoderWrapper {
         }
     }
 
-    public CanCoderWrapper(int canId, double offset) {
+    public CanCoderWrapper(int canId, double offsetRadians) {
         m_encoder = new CANCoder(canId);
+        m_offsetAngleRadians = offsetRadians;
 
         CANCoderConfiguration config = new CANCoderConfiguration();
         config.absoluteSensorRange = AbsoluteSensorRange.Unsigned_0_to_360;
-        config.magnetOffsetDegrees = Math.toDegrees(offset);
+        config.magnetOffsetDegrees = Math.toDegrees(offsetRadians);
         config.sensorDirection = ROTATION_CLOCKWISE;
 
         // set the update period and report any errors
@@ -38,8 +42,12 @@ public class CanCoderWrapper {
                 "Failed to configure CANCoder update rate");
     };
 
+    public double getOffsetAngleRadians() {
+        return m_offsetAngleRadians;
+    }
+
     // get the absolute angle, in radians
-    public double getAbsoluteAngle() {
+    public double getAbsoluteAngleRadians() {
         double angle = Math.toRadians(m_encoder.getAbsolutePosition());
         angle %= 2.0 * Math.PI;
         if (angle < 0.0) {

--- a/src/main/java/frc/robot/swerve/SwerveModule.java
+++ b/src/main/java/frc/robot/swerve/SwerveModule.java
@@ -7,10 +7,12 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 // This has a SteerController and a DriveController
 
 public class SwerveModule {
+    private final String m_moduleName;
     private final NeoDriveController m_driveController;
     private final NeoSteerController m_steerController;
 
-    public SwerveModule(NeoDriveController driveController, NeoSteerController steerController) {
+    public SwerveModule(String moduleName, NeoDriveController driveController, NeoSteerController steerController) {
+        m_moduleName = moduleName;
         m_driveController = driveController;
         m_steerController = steerController;
     }
@@ -68,8 +70,8 @@ public class SwerveModule {
         return m_driveController.getWheelDistance();
     }
 
-    public void updateSmartDashboard(String prefix) {
-        m_steerController.updateSmartDashboard(prefix + "_steer");
+    public void updateSmartDashboard() {
+        m_steerController.updateSmartDashboard(String.format("drivetrain/%s/steer", m_moduleName));
     }
 
     public void syncAngleEncoders(boolean dontCheckTimer) {


### PR DESCRIPTION
This is an attempt to simplify swerve angle offset calibration.

I changes method/variable names to make explicit that the units are radians (I went back and forth on using Rot2d, decided against it).
Gave SwerveModules a name member, to simplify setting SmartDashboard values.

Added a value which I believe is the angle offset, if the modules are physically in the correct position. However, this really needs testing to make sure the signs are correct.